### PR TITLE
Update .gitmodules with proper clone path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/ve"]
 	path = lib/ve
-	url = https://gerrit.wikimedia.org/r/p/VisualEditor/VisualEditor.git
+	url = https://gerrit.wikimedia.org/r/VisualEditor/VisualEditor.git


### PR DESCRIPTION
Gerrit deprecated 'r/p' in repository paths, and now the path is unsupported.